### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for the root Yarn/npm dependency manifest
- keep the generated dependency-update PRs subject to normal review and CI

## Validation

- parsed `.github/dependabot.yml` successfully with Ruby YAML
- `git diff --check`
- confirmed the PR only adds `.github/dependabot.yml`